### PR TITLE
Ensure that used tools actually exist

### DIFF
--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -2,8 +2,9 @@
 
 source "$(dirname $0)/common.sh"
 
-ensure_bin 'mvn'
-ensure_bin 'git'
+ensure_bin 'wget'
+ensure_bin 'jar'
+ensure_bin 'groovy'
 
 mkdir_p $OUTPUT_DIR
 mkdir_p $SITE_DIR


### PR DESCRIPTION
`mvn` and `git` aren't actually used, and `jar` is missing (so **merging this should start failing the build**).

See build logs at https://ci.jenkins.io/job/Infra/job/javadoc/job/master/, e.g.

    ./scripts/generate-javadoc.sh: line 23: jar: command not found
    >> failed to generate javadocs for 1.651