### PR TITLE
Add index file for plugins directory

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -1,0 +1,32 @@
+.missing {
+	color: #999;
+}
+
+a {
+	color: #339;
+	text-decoration: none;
+}
+
+a:hover {
+	color: #66c;
+}
+
+body {
+	font-family: sans-serif;
+}
+
+.version {
+	font-size: small;
+	padding-left: 10px;
+	vertical-align: top;
+}
+
+div {
+	float: left;
+	width: 400px;
+	height: 200px;
+	padding: 20px;
+	margin: 20px;
+	border: 1px solid #ccc;
+	border-radius: 10px;
+}

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -9,11 +9,21 @@ def ant = new AntBuilder()
 // Now we can inject it into the JsonSlurper to produce an object to work with
 def json = new JsonSlurper().parseText(new URL (location).text);
 
+// HTML index file header
+def indexHtml = '' << '<html><head><title>Jenkins Plugins Javadoc</title>'
+indexHtml << '<meta http-equiv="content-type" content="text/html; charset=UTF-8"/>'
+indexHtml << '<link rel="stylesheet" type="text/css" href="style.css"/>'
+indexHtml << '<script src="script.js"></script>'
+indexHtml << '</head><body>'
+
+// define sort order for plugins
+def keyComparator = [compare: { e1, e2 -> e1.key.compareToIgnoreCase(e2.key) }] as Comparator
+
 // For each plugin
-json.plugins.each {it ->
+json.plugins.toSorted(keyComparator).collect { k, v -> v }.eachWithIndex { value, idx ->
 
     // we obtain the GAV value, and tokenize it at the ":"
-    def gav = it.value.gav.split(":");
+    def gav = value.gav.split(":");
 
     // For the GroupID we need to replace the . with a / which is what we search for in the URL
     gid = gav[0].replace(".", "/")
@@ -38,6 +48,10 @@ json.plugins.each {it ->
     // We need an output stream to write the content from the url to the file.
     def fos = file.newOutputStream()
 
+    def name = value.title
+    def id = value.name
+    def version = value.version
+
     try {
         // Write the contents of the *-javadoc.jar to the file
         file << new URL(pluginLoc).openStream()
@@ -47,11 +61,21 @@ json.plugins.each {it ->
                 src:file,
                 dest:plugin_dir,
                 overwrite:true)
+
+        indexHtml << "<div id='${id}'><h2><a href='${id}'>${name}</a><span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p><a href='${id}'>Javadoc</a></p><p><a href='https://plugins.jenkins.io/${id}'>Plugin Information</a></p></div>"
     } catch (FileNotFoundException e) {
 
         // This will only be encountered if there is no javadocs in our repo. We can safely move on.
         println "No javadoc found for: " + aid
+        indexHtml << "<div id='${id}' class='missing'><h2>${name}<span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p>No Javadoc has been published for this plugin.</p><p><a href='https://plugins.jenkins.io/${id}'>Plugin Information</a></p></div>"
     } finally {
         fos.close();
     }
 }
+
+// white index.html file with nicer looking list of links to plugins
+indexHtml << '</body></html>'
+new File("build/site/plugin/index.html").text = indexHtml
+
+// copy CSS anf JS into output
+new File("build/site/plugin/style.css").text = new File("resources/style.css").text


### PR DESCRIPTION
Create an index page for http://javadoc.jenkins.io/plugin/

* Show plugin name, title, version
* Link to plugin site for each plugin
* Also include plugins without Javadoc in the output with explanation why there's nothing there

Current sort order is by plugin name (`artifactId`) case-insensitively, which I think is a good choice, but perhaps not the best (sorting by title would need processing like removing "Hudson"/"Jenkins" prefixes etc. – perhaps later).

![screen shot](https://cloud.githubusercontent.com/assets/1831569/23583517/0086d770-0147-11e7-9822-0ac6a6d8781a.png)
