### PR TITLE
[WEBSITE-386] Add index.json listing plugins with Javadoc and their URL

### DIFF
--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -3,7 +3,7 @@ import groovy.json.*;
 String location = "http://updates.jenkins.io/current/update-center.actual.json"
 String pluginLocation = "https://repo.jenkins-ci.org/releases/"
 
-String baseUrl = "https://javadoc.jenkins.io/plugin/"
+String baseUrl = "http://javadoc.jenkins.io/plugin/"
 
 // AntBuilder used for unzipping content
 def ant = new AntBuilder()


### PR DESCRIPTION
The idea is to allow the plugin site to link to plugin Javadoc from the plugin page. For that to work, we need an easy to consume list of plugins that have Javadoc published.  Add the URL for extra flexibility even if the URL to this JSON file will need to be a configuration option.