### PR TITLE
[INFRA-1305] - Create Dockerfile for local builds and runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM nginx:1.13.3
+
+ARG PUBLISH_PATH=/usr/share/nginx/html
+
+RUN apt-get update
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199, man-db does not help
+RUN mkdir -p /usr/share/man/man1/
+RUN apt-get purge openjdk-7-jre-headless && apt-get install -y openjdk-8-jdk wget ant groovy
+
+RUN apt-get install -y curl
+
+# Just test settings to speedup the startup
+ARG LTS_RELEASES=""
+ARG PLUGINS=""
+
+WORKDIR /opt/build/javadoc
+COPY resources/ /opt/build/javadoc/resources
+COPY scripts/ /opt/build/javadoc/scripts
+RUN bash -ex scripts/generate-javadoc.sh && bash -ex scripts/generate-shortnames.sh && groovy scripts/generate-javadoc-plugins.groovy "${PLUGINS}" && bash -ex scripts/default-to-latest.sh && cp -R /opt/build/javadoc/build/site/* ${PUBLISH_PATH} && rm -rf /opt/build/javadoc
+
+# TODO: Bonus points squash apt-get and build and remove unneccesary packages after the build (or use different builder and prod images)
+
+WORKDIR ${PUBLISH_PATH}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ ARG PLUGINS=""
 WORKDIR /opt/build/javadoc
 COPY resources/ /opt/build/javadoc/resources
 COPY scripts/ /opt/build/javadoc/scripts
-RUN bash -ex scripts/generate-javadoc.sh && bash -ex scripts/generate-shortnames.sh && groovy scripts/generate-javadoc-plugins.groovy "${PLUGINS}" && bash -ex scripts/default-to-latest.sh && cp -R /opt/build/javadoc/build/site/* ${PUBLISH_PATH} && rm -rf /opt/build/javadoc
+RUN bash -ex scripts/generate-javadoc.sh && bash -ex scripts/generate-shortnames.sh && bash -ex scripts/default-to-latest.sh && cp -R /opt/build/javadoc/build/site/* ${PUBLISH_PATH} && rm -rf /opt/build/javadoc
+
 
 # TODO: Bonus points squash apt-get and build and remove unneccesary packages after the build (or use different builder and prod images)
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,46 @@
 = Jenkins Javadocs
 
 This repository contains the scripts necessary to generate javadocs for
-publication inside of the jenkins.io infrastructure
+publication inside of the jenkins.io infrastructure.
+
+Production site is published link:http://javadoc.jenkins.io/[here].
+
+## Structure
+
+* Root `index.html` lists Javadoc of the Jenkins Weekly release
+* Plugin javadoc index can be found at `plugin/`
+* LTS Javadocs can be accessed using links like `archive/jenkins-2.60/`
+
+## Development
+
+The repository offers a `Dockerfile`,
+which can be used for running the build and verifying results.
+
+### Building image
+
+Build command:
+
+```shell
+docker build -t jenkinsinfra/javadoc-dev --build-arg LTS_RELEASES=2.60 --build-arg PLUGINS="git git-client github" .
+```
+
+Optional arguments:
+
+* `LTS_RELEASES` - list of LTS releases to be published
+** Example: "2.46 2.60"
+** Default: all LTS lines returned by link:https://repo.jenkins-ci.org[Jenkins Artifactory]
+** Javadoc for the latest weekly will be published anyway
+* `PLUGINS` - list of plugins to be published
+** Example: "git github git-client"
+** Default: all plugins by the default Jenkins update site
+
+### Running image
+
+Run command:
+
+```shell
+docker run --rm -p 8080:80 jenkinsinfra/javadoc-dev
+```
+
+After starting the image the update site will be available at `DOCKER_HOST:8080`,
+so you will be able to browse the contents similarly tolink:http://javadoc.jenkins.io/[Jenkins Javadoc].

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -24,6 +24,20 @@ def jsonUrlMap = [:]
 // define sort order for plugins
 def keyComparator = [compare: { e1, e2 -> e1.key.compareToIgnoreCase(e2.key) }] as Comparator
 
+Set<String> pluginsAIDs = null;
+if (args.length > 0 && !args[0].trim().empty) {
+    println "Args: ${args.length}, values=${args}"
+    if (pluginsAIDs == null) {
+        pluginsAIDs = new HashSet<>(args.length)
+    }
+
+    def argPluginIDs = args[0].split()
+    for (def pluginID : argPluginIDs) {
+        pluginsAIDs.add(pluginID)
+    }
+    println "Plugins to be published: ${argPluginIDs.join(",")}"
+}
+
 // For each plugin
 json.plugins.toSorted(keyComparator).collect { k, v -> v }.eachWithIndex { value, idx ->
 
@@ -36,6 +50,12 @@ json.plugins.toSorted(keyComparator).collect { k, v -> v }.eachWithIndex { value
     // Get the artifactID and version number as well.
     aid = gav[1]
     ver = gav[2]
+
+    if (pluginsAIDs != null && !pluginsAIDs.contains(aid)) {
+        //TODO: TOO much logging? println "Skipping plugin ${aid}"
+        return
+    }
+    println "Publishing plugin ${aid}"
 
     // The plugin location is defined as:
     // "https://repo.jenkins-ci.org/releases/groupWithSlashes/artifactId/version/artifactId-version-javadoc.jar"

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -31,7 +31,7 @@ if (args.length > 0 && !args[0].trim().empty) {
         pluginsAIDs = new HashSet<>(args.length)
     }
 
-    def argPluginIDs = args[0].split()
+    def argPluginIDs = args[0].trim().split("[\\s,]+")
     for (def pluginID : argPluginIDs) {
         pluginsAIDs.add(pluginID)
     }

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -87,13 +87,13 @@ json.plugins.toSorted(keyComparator).collect { k, v -> v }.eachWithIndex { value
                 dest:plugin_dir,
                 overwrite:true)
 
-        indexHtml << "<div id='${id}'><h2><a href='${id}'>${name}</a><span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p><a href='${id}'>Javadoc</a></p><p><a href='https://plugins.jenkins.io/${id}'>Plugin Information</a></p></div>"
+        indexHtml << "<div id='${id}'><h2><a href='${id}/'>${name}</a><span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p><a href='${id}/'>Javadoc</a></p><p><a href='https://plugins.jenkins.io/${id}/'>Plugin Information</a></p></div>"
         jsonUrlMap[id] = [url: baseUrl + id]
     } catch (FileNotFoundException e) {
 
         // This will only be encountered if there is no javadocs in our repo. We can safely move on.
         println "No javadoc found for: " + aid
-        indexHtml << "<div id='${id}' class='missing'><h2>${name}<span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p>No Javadoc has been published for this plugin.</p><p><a href='https://plugins.jenkins.io/${id}'>Plugin Information</a></p></div>"
+        indexHtml << "<div id='${id}' class='missing'><h2>${name}<span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p>No Javadoc has been published for this plugin.</p><p><a href='https://plugins.jenkins.io/${id}/'>Plugin Information</a></p></div>"
     } finally {
         fos.close();
     }


### PR DESCRIPTION
It should simplify the local development a bit. For me it is a prerequisite for Remoting Javadoc publishing story in [INFRA-1306](https://issues.jenkins-ci.org/browse/INFRA-1306).

- [x] - Allow specifying list of LTS lines and plugins via environment variables in `generate-javadoc.sh`
- [x] - Add Dockerfile
- [x] - Add documentation and extend the repo description
- [x] - Add slashes to URLs in the plugin Javadoc page to make it working with default NGINX settings

https://issues.jenkins-ci.org/browse/INFRA-1305. You can try a sample image from here: https://hub.docker.com/r/onenashev/jenkins-javadoc-dev/

@reviewbybees @rtyler @christ66 @daniel-beck @abayer 