### PR TITLE
[INFRA-1306] - Add Javadocs for Modules and other components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM nginx:1.13.3
+
+ARG PUBLISH_PATH=/usr/share/nginx/html
+
+RUN apt-get update
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199, man-db does not help
+RUN mkdir -p /usr/share/man/man1/
+RUN apt-get purge openjdk-7-jre-headless && apt-get install -y openjdk-8-jdk wget ant groovy
+
+RUN apt-get install -y curl
+
+# Just test settings to speedup the startup
+ARG LTS_RELEASES=""
+ARG PLUGINS=""
+
+WORKDIR /opt/build/javadoc
+COPY resources/ /opt/build/javadoc/resources
+COPY scripts/ /opt/build/javadoc/scripts
+RUN bash -ex scripts/generate-javadoc.sh && bash -ex scripts/generate-shortnames.sh && groovy scripts/generate-javadoc-plugins.groovy "${PLUGINS}" && bash -ex scripts/default-to-latest.sh && cp -R /opt/build/javadoc/build/site/* ${PUBLISH_PATH} && rm -rf /opt/build/javadoc
+
+# TODO: Bonus points squash apt-get and build and remove unneccesary packages after the build (or use different builder and prod images)
+
+WORKDIR ${PUBLISH_PATH}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ ARG PLUGINS=""
 WORKDIR /opt/build/javadoc
 COPY resources/ /opt/build/javadoc/resources
 COPY scripts/ /opt/build/javadoc/scripts
-RUN bash -ex scripts/generate-javadoc.sh && bash -ex scripts/generate-shortnames.sh && groovy scripts/generate-javadoc-plugins.groovy "${PLUGINS}" && bash -ex scripts/default-to-latest.sh && cp -R /opt/build/javadoc/build/site/* ${PUBLISH_PATH} && rm -rf /opt/build/javadoc
+RUN bash -ex scripts/generate-javadoc.sh && bash -ex scripts/generate-shortnames.sh && bash -ex scripts/default-to-latest.sh && cp -R /opt/build/javadoc/build/site/* ${PUBLISH_PATH} && rm -rf /opt/build/javadoc
+
 
 # TODO: Bonus points squash apt-get and build and remove unneccesary packages after the build (or use different builder and prod images)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,12 @@ ARG PLUGINS=""
 WORKDIR /opt/build/javadoc
 COPY resources/ /opt/build/javadoc/resources
 COPY scripts/ /opt/build/javadoc/scripts
+COPY src/ /opt/build/javadoc/src
 RUN bash -ex scripts/generate-javadoc.sh && bash -ex scripts/generate-shortnames.sh && bash -ex scripts/default-to-latest.sh && cp -R /opt/build/javadoc/build/site/* ${PUBLISH_PATH} && rm -rf /opt/build/javadoc
 
+# For testing of particular steps
+#RUN groovy -cp src/main/groovy scripts/generate-javadoc-components.groovy
+#RUN cp -R /opt/build/javadoc/build/site/* ${PUBLISH_PATH}
 
 # TODO: Bonus points squash apt-get and build and remove unneccesary packages after the build (or use different builder and prod images)
 

--- a/README.adoc
+++ b/README.adoc
@@ -7,9 +7,14 @@ Production site is published link:http://javadoc.jenkins.io/[here].
 
 ## Structure
 
-* Root `index.html` lists Javadoc of the Jenkins Weekly release
-* Plugin javadoc index can be found at `plugin/`
-* LTS Javadocs can be accessed using links like `archive/jenkins-2.60/`
+* root - `index.html` lists Javadoc of the Jenkins Weekly release
+* `archive/jenkins-2.60/` - Javadocs for the recent LTS releases
+* `/plugin/` - Plugin javadoc index can be found at `plugin/`
+* `/module/` - Indexes for Jenkins Core modules: `module/`
+** Currently the site lists latest versions of modules.
+Effective versions in the latest core release may differ.
+* `/component/` - Jenkins components and libraries
+** This section does not contain a full list of components so far
 
 ## Development
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,46 @@
 = Jenkins Javadocs
 
 This repository contains the scripts necessary to generate javadocs for
-publication inside of the jenkins.io infrastructure
+publication inside of the jenkins.io infrastructure.
+
+Production site is published link:http://javadoc.jenkins.io/[here].
+
+## Structure
+
+* Root `index.html` lists Javadoc of the Jenkins Weekly release
+* Plugin javadoc index can be found at `plugin/`
+* LTS Javadocs can be accessed using links like `archive/jenkins-2.60/`
+
+## Development
+
+The repository offers a `Dockerfile`,
+which can be used for running the build and verifying results.
+
+### Building image
+
+Build command:
+
+```shell
+docker build -t jenkinsinfra/javadoc-dev --build-arg LTS_RELEASES=2.60 --build-arg PLUGINS="git git-client github" .
+```
+
+Optional arguments:
+
+* `LTS_RELEASES` - list of LTS releases to be published
+** Example: "2.46 2.60"
+** Default: all LTS lines returned by link:https://repo.jenkins-ci.org[Jenkins Artifactory]
+** Javadoc for the latest weekly will be published anyway
+* `PLUGINS` - list of plugins to be published
+** Example: "git github git-client"
+** Default: all plugins by the default Jenkins update site
+
+### Running image
+
+Run command:
+
+```shell
+docker run --rm -p 8080:80 jenkinsinfra/javadoc-dev
+```
+
+After starting the image the update site will be available at `DOCKER_HOST:8080`,
+so you will be able to browse the contents similarly tolink:http://javadoc.jenkins.io/[Jenkins Javadoc].

--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -24,7 +24,7 @@ def indexBuilder = new JavadocGroupBuilder("plugin", "plugin", "Jenkins Plugins 
 String location = "http://updates.jenkins.io/current/update-center.actual.json"
 def json = new JsonSlurper().parseText(new URL (location).text);
 json.plugins.toSorted(keyComparator).collect { k, v -> v }.eachWithIndex { value, idx ->
-    def artifact = Artifact.pluginFromGAV(value.title, value.gav)
+    def artifact = new PluginArtifact(value.title, value.gav)
     indexBuilder.withArtifact(artifact)
 }
 

--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -1,31 +1,20 @@
 import groovy.json.*;
 
 // define sort order for plugins
-def keyComparator = [compare: { e1, e2 -> e1.key.compareToIgnoreCase(e2.key) }] as Comparator
+def keyComparator = [compare: { e1, e2 -> e1.name.compareToIgnoreCase(e2.name) }] as Comparator
 
-Set<String> pluginsAIDs = null;
-if (args.length > 0 && !args[0].trim().empty) {
-    if (pluginsAIDs == null) {
-        pluginsAIDs = new HashSet<>(args.length)
-    }
+def components = new ArrayList<Artifact>();
+components.addAll(Arrays.asList(
+    new Artifact("Remoting", "org.jenkins-ci.main", "remoting", null, "https://github.com/jenkinsci/remoting"),
+    new Artifact("XStream", "org.jvnet.hudson", "xstream", null, "https://github.com/jenkinsci/xstream"),
+    new Artifact("GitHub API", "org.kohsuke", "github-api", null, "http://github-api.kohsuke.org/")
+))
 
-    def argPluginIDs = args[0].trim().split("[\\s,]+")
-    for (def pluginID : argPluginIDs) {
-        pluginsAIDs.add(pluginID)
-    }
-    println "Plugins to be published: ${argPluginIDs.join(",")}"
-}
-
-// Start building the plugin group
-def indexBuilder = new JavadocGroupBuilder("plugin", "plugin", "Jenkins Plugins Javadoc", pluginsAIDs);
 
 // For each plugin located in the update center
-
-String location = "http://updates.jenkins.io/current/update-center.actual.json"
-def json = new JsonSlurper().parseText(new URL (location).text);
-json.plugins.toSorted(keyComparator).collect { k, v -> v }.eachWithIndex { value, idx ->
-    def artifact = new PluginArtifact(value.title, value.gav)
-    indexBuilder.withArtifact(artifact)
+def indexBuilder = new JavadocGroupBuilder("component", "component", "Jenkins Componentss Javadoc");
+components.toSorted(keyComparator).eachWithIndex { value, idx ->
+    indexBuilder.withArtifact(value)
 }
 
 // Build all

--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -12,7 +12,7 @@ components.addAll(Arrays.asList(
 
 
 // For each plugin located in the update center
-def indexBuilder = new JavadocGroupBuilder("component", "component", "Jenkins Componentss Javadoc");
+def indexBuilder = new JavadocGroupBuilder("component", "component", "Jenkins Components Javadoc");
 components.toSorted(keyComparator).eachWithIndex { value, idx ->
     indexBuilder.withArtifact(value)
 }

--- a/scripts/generate-javadoc-modules.groovy
+++ b/scripts/generate-javadoc-modules.groovy
@@ -1,0 +1,30 @@
+import groovy.json.*;
+
+// define sort order for plugins
+def keyComparator = [compare: { e1, e2 -> e1.name.compareToIgnoreCase(e2.name) }] as Comparator
+
+// TODO: automatic module discovery from WAR?
+def modules = new ModuleList()
+modules.add("instance-identity", "Instance Identity")
+modules.add("sshd", "SSHD")
+modules.add("ssh-cli-auth", "SSH CLI client authenticator")
+modules.add("optional-plugin-helper", "Optional Plugin Helper")
+modules.add("domain-discovery", "Instance Discovery via DNS SRV")
+modules.add("slave-installer", "Agent Installer")
+modules.add("windows-slave-installer", "Windows Agent Installer")
+//TODO: Modules below are still names as Slave Installers
+modules.add("launchd-slave-installer", "OS X Agent installer")
+modules.add("systemd-slave-installer", "Systemd Agent installer")
+modules.add("upstart-slave-installer", "Upstart Agent installer")
+
+// For each plugin located in the update center
+def indexBuilder = new JavadocGroupBuilder("module", "module", "Jenkins Modules Javadoc");
+modules.toSorted(keyComparator).eachWithIndex { value, idx ->
+    indexBuilder.withArtifact(value)
+}
+
+// Build all
+indexBuilder.build()
+
+
+

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -24,6 +24,20 @@ def jsonUrlMap = [:]
 // define sort order for plugins
 def keyComparator = [compare: { e1, e2 -> e1.key.compareToIgnoreCase(e2.key) }] as Comparator
 
+Set<String> pluginsAIDs = null;
+if (args.length > 0 && !args[0].trim().empty) {
+    println "Args: ${args.length}, values=${args}"
+    if (pluginsAIDs == null) {
+        pluginsAIDs = new HashSet<>(args.length)
+    }
+
+    def argPluginIDs = args[0].split()
+    for (def pluginID : argPluginIDs) {
+        pluginsAIDs.add(pluginID)
+    }
+    println "Plugins to be published: ${argPluginIDs.join(",")}"
+}
+
 // For each plugin
 json.plugins.toSorted(keyComparator).collect { k, v -> v }.eachWithIndex { value, idx ->
 
@@ -36,6 +50,12 @@ json.plugins.toSorted(keyComparator).collect { k, v -> v }.eachWithIndex { value
     // Get the artifactID and version number as well.
     aid = gav[1]
     ver = gav[2]
+
+    if (pluginsAIDs != null && !pluginsAIDs.contains(aid)) {
+        //TODO: TOO much logging? println "Skipping plugin ${aid}"
+        return
+    }
+    println "Publishing plugin ${aid}"
 
     // The plugin location is defined as:
     // "https://repo.jenkins-ci.org/releases/groupWithSlashes/artifactId/version/artifactId-version-javadoc.jar"

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -31,7 +31,7 @@ if (args.length > 0 && !args[0].trim().empty) {
         pluginsAIDs = new HashSet<>(args.length)
     }
 
-    def argPluginIDs = args[0].split()
+    def argPluginIDs = args[0].trim().split("[\\s,]+")
     for (def pluginID : argPluginIDs) {
         pluginsAIDs.add(pluginID)
     }

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -87,13 +87,13 @@ json.plugins.toSorted(keyComparator).collect { k, v -> v }.eachWithIndex { value
                 dest:plugin_dir,
                 overwrite:true)
 
-        indexHtml << "<div id='${id}'><h2><a href='${id}'>${name}</a><span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p><a href='${id}'>Javadoc</a></p><p><a href='https://plugins.jenkins.io/${id}'>Plugin Information</a></p></div>"
+        indexHtml << "<div id='${id}'><h2><a href='${id}/'>${name}</a><span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p><a href='${id}/'>Javadoc</a></p><p><a href='https://plugins.jenkins.io/${id}/'>Plugin Information</a></p></div>"
         jsonUrlMap[id] = [url: baseUrl + id]
     } catch (FileNotFoundException e) {
 
         // This will only be encountered if there is no javadocs in our repo. We can safely move on.
         println "No javadoc found for: " + aid
-        indexHtml << "<div id='${id}' class='missing'><h2>${name}<span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p>No Javadoc has been published for this plugin.</p><p><a href='https://plugins.jenkins.io/${id}'>Plugin Information</a></p></div>"
+        indexHtml << "<div id='${id}' class='missing'><h2>${name}<span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p>No Javadoc has been published for this plugin.</p><p><a href='https://plugins.jenkins.io/${id}/'>Plugin Information</a></p></div>"
     } finally {
         fos.close();
     }

--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -58,3 +58,5 @@ echo ">> Found release ${LATEST}"
 generate_javadoc_core ${LATEST}
 
 groovy -cp src/main/groovy scripts/generate-javadoc-plugins.groovy "${PLUGINS}"
+//TODO: "libs" would be ideal, but this entry is already full of garbage files
+groovy -cp src/main/groovy scripts/generate-javadoc-components.groovy

--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -58,5 +58,6 @@ echo ">> Found release ${LATEST}"
 generate_javadoc_core ${LATEST}
 
 groovy -cp src/main/groovy scripts/generate-javadoc-plugins.groovy "${PLUGINS}"
-//TODO: "libs" would be ideal, but this entry is already full of garbage files
+# TODO: "libs" would be ideal, but this entry is already full of garbage files
 groovy -cp src/main/groovy scripts/generate-javadoc-components.groovy
+groovy -cp src/main/groovy scripts/generate-javadoc-modules.groovy

--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -57,4 +57,4 @@ LATEST=$(wget -q -O - "https://updates.jenkins.io/current/latestCore.txt")
 echo ">> Found release ${LATEST}"
 generate_javadoc_core ${LATEST}
 
-groovy scripts/generate-javadoc-plugins.groovy "${PLUGINS}"
+groovy -cp src/main/groovy scripts/generate-javadoc-plugins.groovy "${PLUGINS}"

--- a/src/main/groovy/Artifact.groovy
+++ b/src/main/groovy/Artifact.groovy
@@ -1,0 +1,30 @@
+public class Artifact {
+    final String name
+    final String groupID
+    final String artifactID
+    final String version
+    String pageURL
+
+    public Artifact(String name, String groupID, String artifactID, String version = null, String pageURL = null) {
+        this.name = name
+        this.groupID = groupID.replace(".", "/")
+        this.artifactID = artifactID
+        this.version = version
+        this.pageURL = pageURL
+    }
+
+    public static Artifact fromGAV(String name, String gavString, String pageURL = null) {
+        // we obtain the GAV value, and tokenize it at the ":"
+        def gav = gavString.split(":");
+
+        return new Artifact(name, gav[0].replace(".", "/"), gav[1], gav[2], pageURL);
+    }
+
+    public static Artifact pluginFromGAV(String name, String gavString) {
+        // we obtain the GAV value, and tokenize it at the ":"
+        def gav = gavString.split(":");
+
+        return new Artifact(name, gav[0].replace(".", "/"), gav[1], gav[2], "https://plugins.jenkins.io/${gav[1]}");
+    }
+
+}

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -1,0 +1,125 @@
+public class JavadocGroupBuilder {
+
+    private final String path
+    private final String artifactType
+    private final Set<String> artifactIDs
+    private final String pluginLocation
+
+    // AntBuilder used for unzipping content
+    private def indexHtml = new StringBuilder()
+    private def ant = new AntBuilder()
+    private def indexJson = new groovy.json.JsonBuilder()
+    private def jsonUrlMap = [:]
+
+
+    public JavadocGroupBuilder(String path, String artifactType, String title,
+                               Set<String> artifactIDs = null,
+                               String pluginLocation = "https://repo.jenkins-ci.org/releases/"
+                               ) {
+        this.path = path
+        this.artifactType = artifactType
+        this.artifactIDs = artifactIDs
+        this.pluginLocation = pluginLocation
+
+
+        // Header
+        indexHtml << "<html><head><title>${title}</title>"
+        indexHtml << '<meta http-equiv="content-type" content="text/html; charset=UTF-8"/>'
+        indexHtml << '<link rel="stylesheet" type="text/css" href="style.css"/>'
+        indexHtml << '<script src="script.js"></script>'
+        indexHtml << '</head><body>'
+    }
+
+    public JavadocGroupBuilder withArtifact(Artifact artifact) {
+        return withArtifact(artifact.name, artifact.groupID, artifact.artifactID, artifact.version, artifact.pageURL)
+    }
+
+    public JavadocGroupBuilder withArtifact(String name, String gid, String id, String version, String pageURL = null) {
+
+        if (artifactIDs != null && !artifactIDs.contains(id)) {
+            println "Skipping ${artifactType} ${id}"
+            return
+        }
+        println "Publishing ${artifactType} ${id}"
+
+        def repoUrl = pluginLocation + gid + "/" + id + "/"
+        if (version == null) {
+            println "Version is not defined, reading latest from Maven metadata"
+            def metadataURL = repoUrl + "maven-metadata.xml"
+            def metadata = new XmlSlurper().parseText(new URL (metadataURL).text)
+            version = metadata.versioning.latest
+            if (version != null && !version.trim().empty) {
+                println "Located version: ${version}"
+            } else {
+                throw new IllegalStateException("Failed to determine version of ${gid}:${id}")
+            }
+        }
+
+        // The plugin location is defined as:
+        // "https://repo.jenkins-ci.org/releases/groupWithSlashes/artifactId/version/artifactId-version-javadoc.jar"
+        def pluginLoc  = repoUrl + version + "/" + id + "-" + version + "-javadoc.jar";
+
+        // Define the directory as to where the plugin should be extracted to
+        def plugin_dir="build/site/${path}/"+ id + "/"
+
+        // Create the directory where the plugin should exist.
+        new File(plugin_dir).mkdirs();
+
+        // Create the new jar file
+        def file = new File(plugin_dir, "/${id}.jar");
+
+        // We need an output stream to write the content from the url to the file.
+        def fos = file.newOutputStream()
+
+        try {
+            // Write the contents of the *-javadoc.jar to the file
+            file << new URL(pluginLoc).openStream()
+
+            // Unzip the contents to the plugin directory
+            ant.unzip(
+                src:file,
+                dest:plugin_dir,
+                overwrite:true)
+
+            indexHtml << "<div id='${id}'><h2><a href='${id}/'>${name}</a><span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p><a href='${id}/'>Javadoc</a></p><p>${pageHyperlink(pageURL)}</p></div>"
+            jsonUrlMap[id] = [url: pageURL]
+        } catch (FileNotFoundException e) {
+
+            // This will only be encountered if there is no javadocs in our repo. We can safely move on.
+            println "No javadoc found for ${artifactType}: ${id}. Tried ${pluginLoc}"
+            indexHtml << "<div id='${id}' class='missing'><h2>${name}<span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p>No Javadoc has been published for this ${artifactType}.</p><p>${pageHyperlink(pageURL)}</p></div>"
+        } finally {
+            fos.close();
+        }
+
+        return this;
+    }
+
+    public void build() {
+        indexHtml << '</body></html>'
+        new File("build/site/${path}/index.html").text = indexHtml
+
+        // copy CSS anf JS into output
+        new File("build/site/${path}/style.css").text = new File("resources/style.css").text
+
+        // Generate JSON
+        indexJson jsonUrlMap
+        new File("build/site/${path}/index.json").text = indexJson.toString()
+    }
+
+    private String pageHyperlink(String pageURL) {
+        if (pageURL == null) {
+            // Try guessing GitHub repo?
+            return "No homepage found";
+        }
+
+        return "<a href=\"${pageURL}\"/>${capitalizeFirstLetter(this.artifactType)} Information</a>"
+    }
+
+    private String capitalizeFirstLetter(String original) {
+        if (original == null || original.length() == 0) {
+            return original;
+        }
+        return original.substring(0, 1).toUpperCase() + original.substring(1);
+    }
+}

--- a/src/main/groovy/ModuleList.groovy
+++ b/src/main/groovy/ModuleList.groovy
@@ -1,0 +1,15 @@
+public class ModuleList extends ArrayList<Artifact> {
+
+    public void add(String id,
+                   String name = null,
+                   String groupId = "org.jenkins-ci.modules",
+                   String pageURL = null) {
+
+        def artifactName = name ?: "${id}-module"
+        def url = pageURL ?: "https://github.com/jenkinsci/${id}-module"
+
+        // TODO: determine versions from the last core and tweak version?
+        def art = new Artifact(artifactName, groupId, id, null, url);
+        add(art)
+    }
+}


### PR DESCRIPTION
I needed to publish Remoting Javadocs, but after some consideration I decided to hack a more generic engine, which would support Jenkins modules and other libraries

It's built on the top of #14 

- [x] - Move Groovy logic to shared classes
- [x] - Add support of automatic determining of the latest module version from Artifactory
- [x] - Add Javadoc listing for all Jenkins Core modules
- [x] - Add Javadoc listing for several components: Remoting, XStream, GitHub API - Just as examples

Screenshots are below:

<img width="969" alt="screen shot 2017-08-21 at 11 52 56" src="https://user-images.githubusercontent.com/3000480/29514457-f2ef98b6-8668-11e7-87da-8e9ef335cd5d.png">

<img width="963" alt="screen shot 2017-08-21 at 11 53 12" src="https://user-images.githubusercontent.com/3000480/29514468-f920fe82-8668-11e7-86a1-f1c297e9b09e.png">


https://issues.jenkins-ci.org/browse/INFRA-1306

@reviewbybees @rtyler @daniel-beck 