### PR TITLE
Run Monday UTC morning to pick up new weekly Javadoc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '2')),
-    pipelineTriggers([cron('15 3 * * 0')]),
+    pipelineTriggers([cron('H 5 * * 1')]),
 ])
 
 try {


### PR DESCRIPTION
Since we typically release on Pacific daytime Sunday, this will give us a good chance to pick up the new weekly quickly.