### PR TITLE
Add Version Number Library to the Javadoc site

### DIFF
--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -10,6 +10,7 @@ components.addAll(Arrays.asList(
     new Artifact("GitHub API", "org.kohsuke", "github-api", null, "http://github-api.kohsuke.org/"),
     new Artifact("Jenkins Test Harness", "org.jenkins-ci.main", "jenkins-test-harness", null, "https://github.com/jenkinsci/jenkins-test-harness"),
     new Artifact("Remoting", "org.jenkins-ci.main", "remoting", null, "https://github.com/jenkinsci/remoting"),
+    new Artifact("Version Number Lib", "org.jenkins-ci", "version-number", null, "https://github.com/jenkinsci/lib-version-number"),
     new Artifact("XStream", "org.jvnet.hudson", "xstream", null, "https://github.com/jenkinsci/xstream")
 ))
 


### PR DESCRIPTION
https://github.com/jenkinsci/lib-version-number

CC @batmat
