### PR TITLE
Include test-annotations javadoc

### DIFF
--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -9,6 +9,7 @@ components.addAll(Arrays.asList(
     new Artifact("Docker fixtures", "org.jenkins-ci.test", "docker-fixtures", null, "https://github.com/jenkinsci/docker-fixtures"),
     new Artifact("GitHub API", "org.kohsuke", "github-api", null, "http://github-api.kohsuke.org/"),
     new Artifact("Jenkins Test Harness", "org.jenkins-ci.main", "jenkins-test-harness", null, "https://github.com/jenkinsci/jenkins-test-harness"),
+    new Artifact("Test Annotations", "org.jvnet.hudson.test", "test-annotations", null, "https://github.com/jenkinsci/lib-test-annotations"),
     new Artifact("Remoting", "org.jenkins-ci.main", "remoting", null, "https://github.com/jenkinsci/remoting"),
     new Artifact("Version Number Lib", "org.jenkins-ci", "version-number", null, "https://github.com/jenkinsci/lib-version-number"),
     new Artifact("Crypto Util Lib", "org.jenkins-ci", "crypto-util", null, "https://github.com/jenkinsci/lib-crypto-util"),

--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -9,7 +9,7 @@ components.addAll(Arrays.asList(
     new Artifact("Docker fixtures", "org.jenkins-ci.test", "docker-fixtures", null, "https://github.com/jenkinsci/docker-fixtures"),
     new Artifact("GitHub API", "org.kohsuke", "github-api", null, "http://github-api.kohsuke.org/"),
     new Artifact("Jenkins Test Harness", "org.jenkins-ci.main", "jenkins-test-harness", null, "https://github.com/jenkinsci/jenkins-test-harness"),
-    new Artifact("Test Annotations", "org.jvnet.hudson.test", "test-annotations", null, "https://github.com/jenkinsci/lib-test-annotations"),
+    new Artifact("Test Annotations", "org.jvnet.hudson.test", "test-annotations", "1.3", "https://github.com/jenkinsci/lib-test-annotations"),
     new Artifact("Remoting", "org.jenkins-ci.main", "remoting", null, "https://github.com/jenkinsci/remoting"),
     new Artifact("Version Number Lib", "org.jenkins-ci", "version-number", null, "https://github.com/jenkinsci/lib-version-number"),
     new Artifact("Crypto Util Lib", "org.jenkins-ci", "crypto-util", null, "https://github.com/jenkinsci/lib-crypto-util"),

--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -9,7 +9,7 @@ components.addAll(Arrays.asList(
     new Artifact("Docker fixtures", "org.jenkins-ci.test", "docker-fixtures", null, "https://github.com/jenkinsci/docker-fixtures"),
     new Artifact("GitHub API", "org.kohsuke", "github-api", null, "http://github-api.kohsuke.org/"),
     new Artifact("Jenkins Test Harness", "org.jenkins-ci.main", "jenkins-test-harness", null, "https://github.com/jenkinsci/jenkins-test-harness"),
-    new Artifact("Test Annotations", "org.jvnet.hudson.test", "test-annotations", "1.3", "https://github.com/jenkinsci/lib-test-annotations"),
+    new Artifact("Test Annotations", "org.jenkins-ci", "test-annotations", null, "https://github.com/jenkinsci/lib-test-annotations"),
     new Artifact("Remoting", "org.jenkins-ci.main", "remoting", null, "https://github.com/jenkinsci/remoting"),
     new Artifact("Version Number Lib", "org.jenkins-ci", "version-number", null, "https://github.com/jenkinsci/lib-version-number"),
     new Artifact("Crypto Util Lib", "org.jenkins-ci", "crypto-util", null, "https://github.com/jenkinsci/lib-crypto-util"),


### PR DESCRIPTION
The javadoc for the test-annotations package is related to the Jenkins test harness javadoc.  I think it should be included in the Jenkins Components javadoc page at

https://javadoc.jenkins.io/component/