### PR TITLE
Create a root `index.html` with links to other stuff

### DIFF
--- a/scripts/default-to-latest.sh
+++ b/scripts/default-to-latest.sh
@@ -8,3 +8,17 @@ LATESTDIR=${ARCHIVE_DIR}/${LATEST}
 pushd $LATESTDIR
     cp -R * ${SITE_DIR}
 popd
+
+pushd ${SITE_DIR}
+mv index.html index-core.html
+cat > index.html <<EOF
+<html><head><title>Jenkins Javadoc</title>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+<link rel="stylesheet" type="text/css" href="style.css"/>
+<div><h2><a href="index-core.html">Jenkins core</a></div>
+<div><h2><a href="plugin/">Jenkins plugins</a></div>
+<div><h2><a href="component/">Jenkins components</a></div>
+</head><body>
+EOF
+popd
+cp "$(dirname $0)/../resources/style.css" ${SITE_DIR}


### PR DESCRIPTION
Creating an explicit link to the core Javadoc index page as the root page of the site. Otherwise the component and plugin portions of this site are undiscoverable.

I am assuming #26, so not linking to modules.

Also not bothering to link to core archives, which seems a somewhat dubious feature anyway.
