### PR TITLE
[WEBSITE-779] Do not proceed if download failed

### DIFF
--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 source "$(dirname $0)/common.sh"
 
 ensure_bin 'wget'


### PR DESCRIPTION
https://ci.jenkins.io/job/Infra/job/javadoc/job/master/286/consoleFull had an error

```
>> Found release 2.300
https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-core/2.300/jenkins-core-2.300-javadoc.jar:
2021-07-05 05:43:30 ERROR 404: Not Found.
mv: cannot stat 'jenkins-core-2.300-javadoc.jar': No such file or directory
java.io.FileNotFoundException: jenkins-core-2.300-javadoc.jar (No such file or directory)
	at java.io.FileInputStream.open0(Native Method)
	at java.io.FileInputStream.open(FileInputStream.java:195)
	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at java.io.FileInputStream.<init>(FileInputStream.java:93)
	at sun.tools.jar.Main.run(Main.java:307)
	at sun.tools.jar.Main.main(Main.java:1288)
>> failed to generate javadocs for 2.300
```

yet the build proceeded, so now https://javadoc.jenkins.io/index-core.html is a 404. And this is apparently causing some plugin builds to fail, too, since they try to retrieve core Javadoc!
