### PR TITLE
[JENKINS-68768] Javadoc linking errors on Java 8

### DIFF
--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -31,6 +31,21 @@ function generate_javadoc_core() {
         echo ">> failed to generate javadocs for ${release}"
     fi;
 
+    #
+    # Since Java 9, the javadoc(1) command's package-list file has been
+    # superseded by a new element-list file. However, the Java 8 version of
+    # javadoc(1) still consumes the old package-list file. In order to support
+    # both Java 8 and Java 11 builds (including supporting the ability to link
+    # against https://javadoc.jenkins.io), we work around the problem by
+    # ensuring that both package-list and element-list exist. When we no longer
+    # need to support Java 8 builds, this workaround can be deleted.
+    #
+    if [ -e package-list ] && [ ! -e element-list ]; then
+        cp package-list element-list
+    elif [ -e element-list ] && [ ! -e package-list ]; then
+        cp element-list package-list
+    fi
+
     # Move the docs to the archive directory
     cd .. # Leave the current directory
     mv jenkins-core-${release} ${ARCHIVE_DIR}/jenkins-${release}


### PR DESCRIPTION
## Background

See [JENKINS-68768](https://issues.jenkins.io/browse/JENKINS-68768).

### Steps to reproduce

Run `mvn javadoc:javadoc` against e.g. `text-finder` with Java 8.

### Expected results

**Note:** These are the *actual* results when running with Java 11:

No warnings are printed:

```
<INFO> --- maven-javadoc-plugin:3.4.0:javadoc (default-cli) @ text-finder ---
<INFO> Configuration changed, re-generating javadoc.
```

### Actual results

The following warning is printed:

```
[INFO] --- maven-javadoc-plugin:3.3.2:javadoc (default-cli) @ text-finder ---
<INFO> No previous run data found, generating javadoc.
[INFO] 
1 warning
[WARNING] Javadoc Warnings
[WARNING] javadoc: warning - Error fetching URL: https://javadoc.jenkins.io/
```

### Evaluation

This is caused by the renaming of `package-list` to `element-list` in Java 10. I see https://javadoc.jenkins.io/element-list but https://javadoc.jenkins.io/package-list gives a 404 (Javadoc built with Java 11). In contrast, I see https://javadoc.jenkins.io/component/jenkins-test-harness/package-list but https://javadoc.jenkins.io/component/jenkins-test-harness/element-list gives a 404 (Javadoc built with Java 8). When `element-list` is copied to `package-list`, the warning disappears.

### Solution

As long as both Java 8 and Java 11 builds continue to be supported (including supporting the ability to link against https://javadoc.jenkins.io, `element-list` must be copied to `package-list` as in gradle/gradle@5e88351dd456a5252d21f3a7ad25bff1b62a2fd2.

### Testing done

I ran `./scripts/generate-javadoc.sh` against a copy of this code with print statements in each of the 4 if statements added in this PR. I verified that all if statements were executed and that I got examples of each of the 4 print statements. This proves that a computer can successfully execute the code in this PR.

I also verified that there were an equal number of `element-list` files and `package-list` files in the generated site and that their contents were identical.

Finally, I ran `./scripts/default-to-latest.sh` and started a local web server against the generated site. I modified `plugin-pom` to point to `localhost` instead of `javadoc.jenkins.io` and verified that I could no longer reproduce the problem after following the steps to reproduce described in the Jira ticket.