### PR TITLE
[JENKINS-68761] javadoc.jenkins.io navigation issues with Java 11 generated javadoc

### DIFF
--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -31,6 +31,14 @@ function generate_javadoc_core() {
         echo ">> failed to generate javadocs for ${release}"
     fi;
 
+    #
+    # Until JDK-8215291 is backported to Java 11, work around the problem by
+    # munging the file ourselves.
+    #
+    if [ -f search.js ]; then
+        sed -i -e 's/if (ui.item.p == item.l)/if (item.m \&\& ui.item.p == item.l)/g' search.js
+    fi
+
     # Move the docs to the archive directory
     cd .. # Leave the current directory
     mv jenkins-core-${release} ${ARCHIVE_DIR}/jenkins-${release}

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -111,6 +111,7 @@ public class JavadocGroupBuilder {
             }
         }
 
+        /*
          * Since Java 9, the javadoc(1) command's package-list file has been superseded by a new
          * element-list file. However, the Java 8 version of javadoc(1) still consumes the old
          * package-list file. In order to support both Java 8 and Java 11 builds (including

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -92,6 +92,20 @@ public class JavadocGroupBuilder {
             fos.close();
         }
 
+        /*
+         * Until JDK-8215291 is backported to Java 11, work around the problem by munging the file
+         * ourselves.
+         */
+        def search = new File(plugin_dir, 'search.js')
+        if (search.exists()) {
+            def sedParams = ['/usr/bin/sed', '-i', '-e', 's/if (ui.item.p == item.l)/if (item.m \\&\\& ui.item.p == item.l)/g', search.absolutePath] as String[]
+            def sedProc = Runtime.getRuntime().exec(sedParams)
+            def sedReturn = sedProc.waitFor()
+            if (sedReturn != 0) {
+                throw new IllegalStateException('sed failed with ' + sedReturn)
+            }
+        }
+
         return this;
     }
 


### PR DESCRIPTION
### Background

See [JENKINS-68761](https://issues.jenkins.io/browse/JENKINS-68761).

### Steps to reproduce

Generate the Javadoc site, then attempt to search for a class in the Jenkins core or Winstone Javadocs (both compiled with Java 11).

### Expected results

The class is found in the search results, and clicking the link takes you to the class's Javadoc.

### Actual results

The class is found in the search results, but clicking on the link takes you to a nonexistent page.

### Evaluation

This is [JDK-8215291](https://bugs.openjdk.org/browse/JDK-8215291).

### Solution

Pending the merge, release, and subsequent adoption of https://github.com/openjdk/jdk11u-dev/pull/1157, work around the problem by munging the file ourselves.

### Testing done

Built the Javadocs locally and started a web server against the generated site. Reproduced the problem as described above, and could no longer reproduce the problem after these changes.