### PR TITLE
Add CODEOWNERS to request core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkins-infra/core


### PR DESCRIPTION
see e.g https://github.com/jenkins-infra/javadoc/pull/36 which no one noticed

(fyi @basil no one was subscribed to this repo apparently)