### PR TITLE
Add dependabot to update Dockerfile dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 2
+  target-branch: master
+  labels:
+  - skip-changelog


### PR DESCRIPTION
Since the Dockerfile depends on an older version of nginx, let's use dependabot to propose upgrades