### PR TITLE
Use Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG PUBLISH_PATH=/usr/share/nginx/html
 RUN apt-get update
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199, man-db does not help
 RUN mkdir -p /usr/share/man/man1/
-RUN apt-get install -y openjdk-11-jdk wget ant groovy curl
+RUN apt-get install -y openjdk-11-jdk wget ant groovy curl sed
 
 # Just test settings to speedup the startup
 ARG LTS_RELEASES=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ ARG PUBLISH_PATH=/usr/share/nginx/html
 RUN apt-get update
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199, man-db does not help
 RUN mkdir -p /usr/share/man/man1/
-RUN apt-get purge openjdk-7-jre-headless && apt-get install -y openjdk-8-jdk wget ant groovy
-
-RUN apt-get install -y curl
+RUN apt-get install -y openjdk-11-jdk wget ant groovy curl
 
 # Just test settings to speedup the startup
 ARG LTS_RELEASES=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@ FROM nginx:1.22.0
 
 ARG PUBLISH_PATH=/usr/share/nginx/html
 
-RUN apt-get update
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199, man-db does not help
-RUN mkdir -p /usr/share/man/man1/
-RUN apt-get install -y openjdk-11-jdk wget ant groovy curl sed
+RUN apt-get update && apt-get install -y openjdk-11-jdk wget ant groovy curl sed
 
 # Just test settings to speedup the startup
 ARG LTS_RELEASES=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ ARG PUBLISH_PATH=/usr/share/nginx/html
 RUN apt-get update
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199, man-db does not help
 RUN mkdir -p /usr/share/man/man1/
-RUN apt-get install -y openjdk-11-jdk wget ant groovy sed
-RUN apt-get install -y curl
-RUN /bin/sed --version || /usr/bin/sed --version
+RUN apt-get install -y openjdk-11-jdk wget ant groovy curl sed
 
 # Just test settings to speedup the startup
 ARG LTS_RELEASES=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ ARG PUBLISH_PATH=/usr/share/nginx/html
 RUN apt-get update
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199, man-db does not help
 RUN mkdir -p /usr/share/man/man1/
-RUN apt-get install -y openjdk-11-jdk wget ant groovy curl sed
+RUN apt-get install -y openjdk-11-jdk wget ant groovy sed
+RUN apt-get install -y curl
+RUN /bin/sed --version || /usr/bin/sed --version
 
 # Just test settings to speedup the startup
 ARG LTS_RELEASES=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM nginx:1.13.6
+# Use nginx stable
+FROM nginx:1.22.0
 
 ARG PUBLISH_PATH=/usr/share/nginx/html
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,10 @@ try {
 
         stage('Archive') {
             sh 'cd build && tar -cjf javadoc-site.tar.bz2 site'
-            archive 'build/*.tar.bz2'
+            archiveArtifacts artifacts: 'build/*.tar.bz2',
+                             allowEmptyArchive: false,
+                             fingerprint: false,
+                             onlyIfSuccessful: true
         }
 
         if (infra.isTrusted()){

--- a/README.adoc
+++ b/README.adoc
@@ -20,17 +20,17 @@ which can be used for running the build and verifying results.
 Build command:
 
 ```shell
-docker build -t jenkinsinfra/javadoc-dev --build-arg LTS_RELEASES=2.73 --build-arg PLUGINS="credentials git git-client" .
+docker build -t jenkinsinfra/javadoc-dev --build-arg LTS_RELEASES="2.332 2.346" --build-arg PLUGINS="credentials git git-client" .
 ```
 
 Optional arguments:
 
 * `LTS_RELEASES` - list of LTS releases to be published
-** Example: "2.60 2.73"
+** Example: "2.332 2.346"
 ** Default: all LTS lines returned by link:https://repo.jenkins-ci.org[Jenkins Artifactory]
 ** Javadoc for the latest weekly will be published anyway
 * `PLUGINS` - list of plugins to be published
-** Example: "git github git-client"
+** Example: "credentials git git-client"
 ** Default: all plugins by the default Jenkins update site
 
 ### Running image

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -103,7 +103,7 @@ public class JavadocGroupBuilder {
          */
         def search = new File(plugin_dir, 'search.js')
         if (search.exists()) {
-            def sedParams = ['/usr/bin/sed', '-i', '-e', 's/if (ui.item.p == item.l)/if (item.m \\&\\& ui.item.p == item.l)/g', search.absolutePath] as String[]
+            def sedParams = ['sed', '-i', '-e', 's/if (ui.item.p == item.l)/if (item.m \\&\\& ui.item.p == item.l)/g', search.absolutePath] as String[]
             def sedProc = Runtime.getRuntime().exec(sedParams)
             def sedReturn = sedProc.waitFor()
             if (sedReturn != 0) {


### PR DESCRIPTION
## Use Java 11 and more recent nginx image

- Use nginx stable (1.22.0), not 1.13.6
- Install Java 11, not Java 8
- Update examples in README
- Add sed package, needed for build process
- Rely on PATH to find sed program
- Fewer calls to apt-get
- Remove Java 8 workaround, simplify apt-get calls
