### PR TITLE
chore: Use jdk11 over jdk8 for gen step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build/
 *.sw*
-
+.idea

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,9 +20,9 @@ try {
         stage('Generate Javadocs') {
             withEnv([
                     "PATH+MVN=${tool 'mvn'}/bin",
-                    "JAVA_HOME=${tool 'jdk8'}",
+                    "JAVA_HOME=${tool 'jdk11'}",
                     "PATH+GROOVY=${tool 'groovy'}/bin",
-                    "PATH+JAVA=${tool 'jdk8'}/bin",
+                    "PATH+JAVA=${tool 'jdk11'}/bin",
                 ]) {
                 sh './scripts/generate-javadoc.sh'
             }
@@ -72,13 +72,4 @@ try {
             }
         }
     }
-}
-catch (exc) {
-    String recipient = 'infra@lists.jenkins-ci.org'
-
-    mail subject: "${env.JOB_NAME} (${env.BUILD_NUMBER}) failed",
-            body: "It appears that ${env.BUILD_URL} is failing, somebody should do something about that",
-              to: recipient,
-         replyTo: recipient,
-            from: 'noreply@ci.jenkins.io'
 }

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -21,7 +21,7 @@ def indexBuilder = new JavadocGroupBuilder("plugin", "plugin", "Jenkins Plugins 
 
 // For each plugin located in the update center
 
-String location = "http://updates.jenkins.io/current/update-center.actual.json"
+String location = "https://updates.jenkins.io/current/update-center.actual.json"
 def json = new JsonSlurper().parseText(new URL (location).text);
 json.plugins.toSorted(keyComparator).collect { k, v -> v }.eachWithIndex { value, idx ->
     def artifact = Artifact.pluginFromGAV(value.title, value.gav)


### PR DESCRIPTION
Follow up to https://github.com/jenkins-infra/javadoc/pull/41, which downloads Java 11 but uses Java 8 for generation.
Additionally, I got a rid of the old mailing list and use https over http to access the UC content.