### PR TITLE
fix: Remove try block

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,6 @@ properties([
     pipelineTriggers([cron('H 5 * * 1')]),
 ])
 
-try {
     node('linux') {
         checkout scm
 
@@ -72,4 +71,3 @@ try {
             }
         }
     }
-}


### PR DESCRIPTION
We can't have a try block without a catch phrase...

This PR build will fail, because the master branch build is broken and forks modifying Jenkinsfiles use the base repository revision.