### PR TITLE
Remove `executable-war`

### DIFF
--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -7,7 +7,6 @@ def components = new ArrayList<Artifact>();
 components.addAll(Arrays.asList(
     new Artifact("Acceptance Test Harness", "org.jenkins-ci", "acceptance-test-harness", null, "https://github.com/jenkinsci/acceptance-test-harness"),
     new Artifact("Docker fixtures", "org.jenkins-ci.test", "docker-fixtures", null, "https://github.com/jenkinsci/docker-fixtures"),
-    new Artifact("Executable WAR header", "org.jenkins-ci", "executable-war", null, "https://github.com/jenkinsci/extras-executable-war"),
     new Artifact("File Leak Detector", "org.kohsuke", "file-leak-detector", null, "https://github.com/jenkinsci/lib-file-leak-detector"),
     new Artifact("GitHub API", "org.kohsuke", "github-api", null, "http://github-api.kohsuke.org/"),
     new Artifact("Jenkins Test Harness", "org.jenkins-ci.main", "jenkins-test-harness", null, "https://github.com/jenkinsci/jenkins-test-harness"),


### PR DESCRIPTION
This component has been inlined to Jenkins core and archived.