### PR TITLE
Skip corrupt javadoc jar files

### DIFF
--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -93,6 +93,11 @@ public class JavadocGroupBuilder {
             // This will only be encountered if there is no javadocs in our repo. We can safely move on.
             println "No javadoc found for ${artifactType}: ${id}. Tried ${pluginLoc}"
             indexHtml << "<div id='${id}' class='missing'><h2>${name}<span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p>No Javadoc has been published for this ${artifactType}.</p><p>${pageHyperlink(pageURL)}</p></div>"
+        } catch (org.apache.tools.ant.BuildException e) {
+
+            // This has happened when javadocs were corrupt in the repo. We can safely move on.
+            println "Corrupt javadoc found for ${artifactType}: ${id}. Tried ${pluginLoc} got exception ${e}"
+            indexHtml << "<div id='${id}' class='missing'><h2>${name}<span class='version'>${version}</span></h2><p><tt>${id}</tt></p><p>Corrupt Javadoc published for this ${artifactType}.</p><p>${pageHyperlink(pageURL)}</p></div>"
         } finally {
             fos.close();
         }


### PR DESCRIPTION
## Skip corrupt javadoc files

Fixes 
* https://github.com/jenkins-infra/helpdesk/issues/3290

https://github.com/jenkins-infra/helpdesk/issues/3290 reports that javadoc builds have been failing since the release of the zdevops plugin 1.0.0.  Core javadoc is still documenting Jenkins 2.380 even though we have released 2.381 and 2.382.

When the javadoc zip file is empty or otherwise corrupt, we can safely ignore it and continue to generate the rest of the javadoc site.  No need to crash the javadoc site generation just because a damaged or flawed javadoc jar file has been published.

It is unfortunate that @IBA-mainframe-dev has not responded to the [issue](https://github.com/jenkins-infra/helpdesk/issues/3290), but the javadoc site creator script is better if it handles corrupt files without crashing.
