### PR TITLE
chore: update `stapler` GitHub organization from `stapler` to `jenkinsci`

### DIFF
--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -15,7 +15,7 @@ components.addAll(Arrays.asList(
     new Artifact("Test Annotations", "org.jenkins-ci", "test-annotations", null, "https://github.com/jenkinsci/lib-test-annotations"),
     new Artifact("Memory Monitor Lib", "org.jenkins-ci", "memory-monitor", null, "https://github.com/jenkinsci/extras-memory-monitor"),
     new Artifact("Remoting", "org.jenkins-ci.main", "remoting", null, "https://github.com/jenkinsci/remoting"),
-    new Artifact("Stapler", "org.kohsuke.stapler", "stapler", null, "https://github.com/stapler/stapler"),
+    new Artifact("Stapler", "org.kohsuke.stapler", "stapler", null, "https://github.com/jenkinsci/stapler"),
     new Artifact("Task Reactor Lib", "org.jenkins-ci", "task-reactor", null, "https://github.com/jenkinsci/lib-task-reactor"),
     new Artifact("Version Number Lib", "org.jenkins-ci", "version-number", null, "https://github.com/jenkinsci/lib-version-number"),
     new Artifact("Crypto Util Lib", "org.jenkins-ci", "crypto-util", null, "https://github.com/jenkinsci/lib-crypto-util"),


### PR DESCRIPTION
As [the `stapler` repository](https://github.com/jenkinsci/stapler) has been moved to the @jenkinsci GitHub organization, this PR updates its URL.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2466