### PR TITLE
Use artifact caching proxy for Javadoc generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,60 +5,59 @@ properties([
     pipelineTriggers([cron('H 5 * * 1')]),
 ])
 
-    node('linux') {
-        checkout scm
+node('linux') {
+    checkout scm
 
-        dir("scripts/build") {
-            deleteDir()
-        }
+    dir("scripts/build") {
+        deleteDir()
+    }
 
-        dir("build") {
-            deleteDir()
-        }
+    dir("build") {
+        deleteDir()
+    }
 
-        def repositoryOrigin = "https://repo." + (env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure') + ".jenkins.io"
+    def repositoryOrigin = "https://repo." + (env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure') + ".jenkins.io"
 
-        stage('Generate Javadocs') {
-            withEnv([
-                    "PATH+MVN=${tool 'mvn'}/bin",
-                    "JAVA_HOME=${tool 'jdk11'}",
-                    "PATH+GROOVY=${tool 'groovy'}/bin",
-                    "PATH+JAVA=${tool 'jdk11'}/bin",
-                    "ARTIFACT_CACHING_PROXY_ORIGIN=${repositoryOrigin}",
-                ]) {
-                withCredentials([usernamePassword(
-                    credentialsId: 'artifact-caching-proxy-credentials',
-                    usernameVariable: 'ARTIFACT_CACHING_PROXY_USERNAME',
-                    passwordVariable: 'ARTIFACT_CACHING_PROXY_PASSWORD'
-                )]) {
-                        sh './scripts/generate-javadoc.sh'
-                    }
-                }
+    stage('Generate Javadocs') {
+        withEnv([
+                "PATH+MVN=${tool 'mvn'}/bin",
+                "JAVA_HOME=${tool 'jdk11'}",
+                "PATH+GROOVY=${tool 'groovy'}/bin",
+                "PATH+JAVA=${tool 'jdk11'}/bin",
+                "ARTIFACT_CACHING_PROXY_ORIGIN=${repositoryOrigin}"
+        ]) {
+            withCredentials([usernamePassword(
+                credentialsId: 'artifact-caching-proxy-credentials',
+                usernameVariable: 'ARTIFACT_CACHING_PROXY_USERNAME',
+                passwordVariable: 'ARTIFACT_CACHING_PROXY_PASSWORD'
+            )]) {
+                sh './scripts/generate-javadoc.sh'
             }
         }
+    }
 
-        stage('Generate Shortnames') {
-            sh './scripts/generate-shortnames.sh'
-        }
+    stage('Generate Shortnames') {
+        sh './scripts/generate-shortnames.sh'
+    }
 
-        stage('Prepare Latest') {
-            sh './scripts/default-to-latest.sh'
-        }
+    stage('Prepare Latest') {
+        sh './scripts/default-to-latest.sh'
+    }
 
-        stage('Archive') {
-            sh 'cd build && tar -cjf javadoc-site.tar.bz2 site'
-            archiveArtifacts artifacts: 'build/*.tar.bz2',
-                             allowEmptyArchive: false,
-                             fingerprint: false,
-                             onlyIfSuccessful: true
-        }
+    stage('Archive') {
+        sh 'cd build && tar -cjf javadoc-site.tar.bz2 site'
+        archiveArtifacts artifacts: 'build/*.tar.bz2',
+                            allowEmptyArchive: false,
+                            fingerprint: false,
+                            onlyIfSuccessful: true
+    }
 
-        if (infra.isTrusted()){
-          stage('Publish on Azure') {
-              /* -> https://github.com/Azure/blobxfer
-              Require credential 'JAVADOC_STORAGEACCOUNTKEY' set to the storage account key */
+    if (infra.isTrusted()){
+        stage('Publish on Azure') {
+            /* -> https://github.com/Azure/blobxfer
+            Require credential 'JAVADOC_STORAGEACCOUNTKEY' set to the storage account key */
             withCredentials([string(credentialsId: 'JAVADOC_STORAGEACCOUNTKEY', variable: 'JAVADOC_STORAGEACCOUNTKEY')]) {
-              sh './scripts/blobxfer upload \
+                sh './scripts/blobxfer upload \
                 --local-path /data/site \
                 --storage-account-key $JAVADOC_STORAGEACCOUNTKEY \
                 --storage-account prodjavadoc \
@@ -70,14 +69,14 @@ properties([
                 --connect-timeout 30 \
                 --delete'
             }
-          }
-        }
-
-
-        stage('Clean up') {
-            echo 'We want to generate fresh javadocs on each run'
-            dir('build/site') {
-                deleteDir()
-            }
         }
     }
+
+
+    stage('Clean up') {
+        echo 'We want to generate fresh javadocs on each run'
+        dir('build/site') {
+            deleteDir()
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,21 +19,19 @@ node('linux') {
     def repositoryOrigin = "https://repo." + (env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure') + ".jenkins.io"
 
     stage('Generate Javadocs') {
-        retry(3) {
-            withEnv([
-                    "PATH+MVN=${tool 'mvn'}/bin",
-                    "JAVA_HOME=${tool 'jdk11'}",
-                    "PATH+GROOVY=${tool 'groovy'}/bin",
-                    "PATH+JAVA=${tool 'jdk11'}/bin",
-                    "ARTIFACT_CACHING_PROXY_ORIGIN=${repositoryOrigin}"
-            ]) {
-                withCredentials([usernamePassword(
-                    credentialsId: 'artifact-caching-proxy-credentials',
-                    usernameVariable: 'ARTIFACT_CACHING_PROXY_USERNAME',
-                    passwordVariable: 'ARTIFACT_CACHING_PROXY_PASSWORD'
-                )]) {
-                    sh './scripts/generate-javadoc.sh'
-                }
+        withEnv([
+                "PATH+MVN=${tool 'mvn'}/bin",
+                "JAVA_HOME=${tool 'jdk11'}",
+                "PATH+GROOVY=${tool 'groovy'}/bin",
+                "PATH+JAVA=${tool 'jdk11'}/bin",
+                "ARTIFACT_CACHING_PROXY_ORIGIN=${repositoryOrigin}"
+        ]) {
+            withCredentials([usernamePassword(
+                credentialsId: 'artifact-caching-proxy-credentials',
+                usernameVariable: 'ARTIFACT_CACHING_PROXY_USERNAME',
+                passwordVariable: 'ARTIFACT_CACHING_PROXY_PASSWORD'
+            )]) {
+                sh './scripts/generate-javadoc.sh'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,14 +16,24 @@ properties([
             deleteDir()
         }
 
+        def repositoryOrigin = "https://repo." + (env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure') + ".jenkins.io"
+
         stage('Generate Javadocs') {
             withEnv([
                     "PATH+MVN=${tool 'mvn'}/bin",
                     "JAVA_HOME=${tool 'jdk11'}",
                     "PATH+GROOVY=${tool 'groovy'}/bin",
                     "PATH+JAVA=${tool 'jdk11'}/bin",
+                    "ARTIFACT_CACHING_PROXY_ORIGIN=${repositoryOrigin}",
                 ]) {
-                sh './scripts/generate-javadoc.sh'
+                withCredentials([usernamePassword(
+                    credentialsId: 'artifact-caching-proxy-credentials',
+                    usernameVariable: 'ARTIFACT_CACHING_PROXY_USERNAME',
+                    passwordVariable: 'ARTIFACT_CACHING_PROXY_PASSWORD'
+                )]) {
+                        sh './scripts/generate-javadoc.sh'
+                    }
+                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '2')),
-    pipelineTriggers([cron('H 5 * * 1')]), 
+    pipelineTriggers([cron('H 5 * * 1')]),
 ])
 
 node('linux') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '2')),
-    pipelineTriggers([cron('H 5 * * 1')]),
+    pipelineTriggers([cron('H 5 * * 1')]), 
 ])
 
 node('linux') {
@@ -19,19 +19,21 @@ node('linux') {
     def repositoryOrigin = "https://repo." + (env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure') + ".jenkins.io"
 
     stage('Generate Javadocs') {
-        withEnv([
-                "PATH+MVN=${tool 'mvn'}/bin",
-                "JAVA_HOME=${tool 'jdk11'}",
-                "PATH+GROOVY=${tool 'groovy'}/bin",
-                "PATH+JAVA=${tool 'jdk11'}/bin",
-                "ARTIFACT_CACHING_PROXY_ORIGIN=${repositoryOrigin}"
-        ]) {
-            withCredentials([usernamePassword(
-                credentialsId: 'artifact-caching-proxy-credentials',
-                usernameVariable: 'ARTIFACT_CACHING_PROXY_USERNAME',
-                passwordVariable: 'ARTIFACT_CACHING_PROXY_PASSWORD'
-            )]) {
-                sh './scripts/generate-javadoc.sh'
+        retry(3) {
+            withEnv([
+                    "PATH+MVN=${tool 'mvn'}/bin",
+                    "JAVA_HOME=${tool 'jdk11'}",
+                    "PATH+GROOVY=${tool 'groovy'}/bin",
+                    "PATH+JAVA=${tool 'jdk11'}/bin",
+                    "ARTIFACT_CACHING_PROXY_ORIGIN=${repositoryOrigin}"
+            ]) {
+                withCredentials([usernamePassword(
+                    credentialsId: 'artifact-caching-proxy-credentials',
+                    usernameVariable: 'ARTIFACT_CACHING_PROXY_USERNAME',
+                    passwordVariable: 'ARTIFACT_CACHING_PROXY_PASSWORD'
+                )]) {
+                    sh './scripts/generate-javadoc.sh'
+                }
             }
         }
     }

--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -33,7 +33,6 @@ components.addAll(Arrays.asList(
 
 // Use the artifact caching proxy if defined
 String pluginLocation = (System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") + "/releases/" : "https://repo.jenkins-ci.org/releases/";
-System.out.println("pluginLocation: " + pluginLocation)
 
 // For each plugin located in the update center
 def indexBuilder = new JavadocGroupBuilder("component", "component", "Jenkins Components Javadoc", null, pluginLocation);

--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -33,6 +33,7 @@ components.addAll(Arrays.asList(
 
 // Use the artifact caching proxy if defined
 String pluginLocation = (System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") + "/releases/" : "https://repo.jenkins-ci.org/releases/";
+System.out.println("pluginLocation: " + pluginLocation)
 
 // For each plugin located in the update center
 def indexBuilder = new JavadocGroupBuilder("component", "component", "Jenkins Components Javadoc", null, pluginLocation);

--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -31,9 +31,11 @@ components.addAll(Arrays.asList(
     new Artifact("Winstone", "org.jenkins-ci", "winstone", null, "https://github.com/jenkinsci/winstone")
 ))
 
+// Use the artifact caching proxy if defined
+String pluginLocation = (System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") + "/releases/" : "https://repo.jenkins-ci.org/releases/";
 
 // For each plugin located in the update center
-def indexBuilder = new JavadocGroupBuilder("component", "component", "Jenkins Components Javadoc");
+def indexBuilder = new JavadocGroupBuilder("component", "component", "Jenkins Components Javadoc", null, pluginLocation);
 components.toSorted(keyComparator).eachWithIndex { value, idx ->
     indexBuilder.withArtifact(value)
 }

--- a/scripts/generate-javadoc-components.groovy
+++ b/scripts/generate-javadoc-components.groovy
@@ -33,9 +33,11 @@ components.addAll(Arrays.asList(
 
 // Use the artifact caching proxy if defined
 String pluginLocation = (System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") + "/releases/" : "https://repo.jenkins-ci.org/releases/";
+String username = System.getenv("ARTIFACT_CACHING_PROXY_USERNAME") ?: null
+String password = System.getenv("ARTIFACT_CACHING_PROXY_PASSWORD") ?: null
 
 // For each plugin located in the update center
-def indexBuilder = new JavadocGroupBuilder("component", "component", "Jenkins Components Javadoc", null, pluginLocation);
+def indexBuilder = new JavadocGroupBuilder("component", "component", "Jenkins Components Javadoc", null, pluginLocation, username, password)
 components.toSorted(keyComparator).eachWithIndex { value, idx ->
     indexBuilder.withArtifact(value)
 }

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -17,10 +17,12 @@ if (args.length > 0 && !args[0].trim().empty) {
 }
 
 // Use the artifact caching proxy if defined
-String pluginLocation = (System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") + "/releases/" : "https://repo.jenkins-ci.org/releases/";
+String pluginLocation = System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") + "/releases/" : "https://repo.jenkins-ci.org/releases/"
+String username = System.getenv("ARTIFACT_CACHING_PROXY_USERNAME") ?: null
+String password = System.getenv("ARTIFACT_CACHING_PROXY_PASSWORD") ?: null
 
 // Start building the plugin group
-def indexBuilder = new JavadocGroupBuilder("plugin", "plugin", "Jenkins Plugins Javadoc", pluginsAIDs, pluginLocation);
+def indexBuilder = new JavadocGroupBuilder("plugin", "plugin", "Jenkins Plugins Javadoc", pluginsAIDs, pluginLocation, username, password)
 
 // For each plugin located in the update center
 

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -17,7 +17,7 @@ if (args.length > 0 && !args[0].trim().empty) {
 }
 
 // Use the artifact caching proxy if defined
-String pluginLocation = System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") + "/releases/" : "https://repo.jenkins-ci.org/releases/"
+String pluginLocation = (System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") + "/releases/" : "https://repo.jenkins-ci.org/releases/"
 String username = System.getenv("ARTIFACT_CACHING_PROXY_USERNAME") ?: null
 String password = System.getenv("ARTIFACT_CACHING_PROXY_PASSWORD") ?: null
 

--- a/scripts/generate-javadoc-plugins.groovy
+++ b/scripts/generate-javadoc-plugins.groovy
@@ -16,8 +16,11 @@ if (args.length > 0 && !args[0].trim().empty) {
     println "Plugins to be published: ${argPluginIDs.join(",")}"
 }
 
+// Use the artifact caching proxy if defined
+String pluginLocation = (System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") != null) ? System.getenv("ARTIFACT_CACHING_PROXY_ORIGIN") + "/releases/" : "https://repo.jenkins-ci.org/releases/";
+
 // Start building the plugin group
-def indexBuilder = new JavadocGroupBuilder("plugin", "plugin", "Jenkins Plugins Javadoc", pluginsAIDs);
+def indexBuilder = new JavadocGroupBuilder("plugin", "plugin", "Jenkins Plugins Javadoc", pluginsAIDs, pluginLocation);
 
 // For each plugin located in the update center
 

--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -16,7 +16,7 @@ mkdir_p "$ARCHIVE_DIR"
 function generate_javadoc_core() {
 	declare release=$1
 	# First we need to get the built javadocs.
-	if [ -n ${ARTIFACT_CACHING_PROXY_ORIGIN-} ]
+	if [[ -n ${ARTIFACT_CACHING_PROXY_ORIGIN-} ]]
 	then
 		wget --no-verbose --http-user=${ARTIFACT_CACHING_PROXY_USERNAME} --http-password=${ARTIFACT_CACHING_PROXY_PASSWORD} "${ARTIFACT_CACHING_PROXY_ORIGIN}/releases/org/jenkins-ci/main/jenkins-core/${release}/jenkins-core-${release}-javadoc.jar"
 	else

--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -16,7 +16,7 @@ mkdir_p "$ARCHIVE_DIR"
 function generate_javadoc_core() {
 	declare release=$1
 	# First we need to get the built javadocs.
-	if [[ -n ${ARTIFACT_CACHING_PROXY_ORIGIN-} ]]
+	if [[ -n "${ARTIFACT_CACHING_PROXY_ORIGIN-}" ]]
 	then
 		wget --no-verbose --http-user=${ARTIFACT_CACHING_PROXY_USERNAME} --http-password=${ARTIFACT_CACHING_PROXY_PASSWORD} "${ARTIFACT_CACHING_PROXY_ORIGIN}/releases/org/jenkins-ci/main/jenkins-core/${release}/jenkins-core-${release}-javadoc.jar"
 	else

--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -13,10 +13,14 @@ mkdir_p "$OUTPUT_DIR"
 mkdir_p "$SITE_DIR"
 mkdir_p "$ARCHIVE_DIR"
 
+# Retrieve the artifact caching proxy provider defined on the agent running the script
+# or using the Azure one as default if none is defined
+CURRENT_ACP_PROVIDER="${ARTIFACT_CACHING_PROXY_PROVIDER:-azure}"
+
 function generate_javadoc_core() {
 	declare release=$1
 	# First we need to get the built javadocs.
-	wget --no-verbose "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-core/${release}/jenkins-core-${release}-javadoc.jar"
+	wget --no-verbose "https://repo.${CURRENT_ACP_PROVIDER}.jenkins.io/releases/org/jenkins-ci/main/jenkins-core/${release}/jenkins-core-${release}-javadoc.jar"
 
 	# We need to move the contents to a new directory to then extract the content.
 	mkdir "jenkins-core-${release}"
@@ -80,7 +84,7 @@ if [[ -z ${LTS_RELEASES} ]]; then
 		[[ -n $LTS_RELEASES ]] && LTS_RELEASES+=' '
 		LTS_RELEASES+="$version"
 		i=$((i + 1))
-	done < <(curl 'https://repo.jenkins-ci.org/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | ./jq --raw-output '.results[].version' | sort -rV)
+	done < <(curl 'https://repo.${CURRENT_ACP_PROVIDER}.jenkins.io/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | ./jq --raw-output '.results[].version' | sort -rV)
 fi
 
 set +o pipefail

--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -16,11 +16,13 @@ mkdir_p "$ARCHIVE_DIR"
 # Retrieve the artifact caching proxy provider defined on the agent running the script
 # or using the Azure one as default if none is defined
 CURRENT_ACP_PROVIDER="${ARTIFACT_CACHING_PROXY_PROVIDER:-azure}"
+echo "ARTIFACT_CACHING_PROXY_PROVIDER: $ARTIFACT_CACHING_PROXY_PROVIDER"
+echo "CURRENT_ACP_PROVIDER: $CURRENT_ACP_PROVIDER"
 
 function generate_javadoc_core() {
 	declare release=$1
 	# First we need to get the built javadocs.
-	wget --no-verbose "https://repo.${CURRENT_ACP_PROVIDER}.jenkins.io/releases/org/jenkins-ci/main/jenkins-core/${release}/jenkins-core-${release}-javadoc.jar"
+	wget --no-verbose "https://repo.$CURRENT_ACP_PROVIDER.jenkins.io/releases/org/jenkins-ci/main/jenkins-core/${release}/jenkins-core-${release}-javadoc.jar"
 
 	# We need to move the contents to a new directory to then extract the content.
 	mkdir "jenkins-core-${release}"

--- a/scripts/generate-javadoc.sh
+++ b/scripts/generate-javadoc.sh
@@ -16,8 +16,6 @@ mkdir_p "$ARCHIVE_DIR"
 # Retrieve the artifact caching proxy provider defined on the agent running the script
 # or using the Azure one as default if none is defined
 CURRENT_ACP_PROVIDER="${ARTIFACT_CACHING_PROXY_PROVIDER:-azure}"
-echo "ARTIFACT_CACHING_PROXY_PROVIDER: $ARTIFACT_CACHING_PROXY_PROVIDER"
-echo "CURRENT_ACP_PROVIDER: $CURRENT_ACP_PROVIDER"
 
 function generate_javadoc_core() {
 	declare release=$1
@@ -86,7 +84,7 @@ if [[ -z ${LTS_RELEASES} ]]; then
 		[[ -n $LTS_RELEASES ]] && LTS_RELEASES+=' '
 		LTS_RELEASES+="$version"
 		i=$((i + 1))
-	done < <(curl 'https://repo.${CURRENT_ACP_PROVIDER}.jenkins.io/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*' | ./jq --raw-output '.results[].version' | sort -rV)
+	done < <(curl "https://repo.${CURRENT_ACP_PROVIDER}.jenkins.io/api/search/versions?g=org.jenkins-ci.main&a=jenkins-core&repos=releases&v=?.*.*" | ./jq --raw-output '.results[].version' | sort -rV)
 fi
 
 set +o pipefail

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -70,7 +70,7 @@ public class JavadocGroupBuilder {
                     conn.setRequestProperty("Accept-Charset", "UTF-8")
                     conn.setRequestProperty("Accept-Encoding", "identity")
                     conn.setRequestProperty("User-Agent", "javadoc-generator/0.1")
-                    conn.setRequestProperty("Authorization", "Basic " + new String(Base64.getEncoder().encode(this.username + ':' + this.password).getBytes("UTF-8"), "UTF-8"))
+                    conn.setRequestProperty("Authorization", "Basic " + new String(Base64.getEncoder().encode((this.username + ':' + this.password).getBytes("UTF-8")), "UTF-8"))
                     BufferedReader inBR = new BufferedReader(new InputStreamReader(conn.getInputStream()))
                     StringBuilder urlContent = new StringBuilder()
                     String inputLine
@@ -118,7 +118,7 @@ public class JavadocGroupBuilder {
                     conn.setRequestProperty("Accept-Charset", "UTF-8")
                     conn.setRequestProperty("Accept-Encoding", "identity")
                     conn.setRequestProperty("User-Agent", "javadoc-generator/0.1")
-                    conn.setRequestProperty("Authorization", "Basic " + new String(Base64.getEncoder().encode(this.username + ':' + this.password).getBytes("UTF-8"), "UTF-8"))
+                    conn.setRequestProperty("Authorization", "Basic " + new String(Base64.getEncoder().encode((this.username + ':' + this.password).getBytes("UTF-8")), "UTF-8"))
                     file << conn.getInputStream()
                 } catch(UnsupportedEncodingException uee) {
                     uee.printStackTrace();

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -1,6 +1,8 @@
+import java.io.BufferedReader
 import java.io.IOException
 import java.io.UncheckedIOException
 import java.io.UnsupportedEncodingException
+import java.lang.StringBuilder
 import java.net.URLConnection
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -70,7 +70,7 @@ public class JavadocGroupBuilder {
                     while ((inputLine = inBR.readLine()) != null) {
                         urlContent.append(inputLine)
                     }
-                    in.close()
+                    inBR.close()
                     def metadata = new XmlSlurper().parseText(urlContent.toString())
                 } catch(UnsupportedEncodingException uee) {
                     uee.printStackTrace();

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -61,7 +61,6 @@ public class JavadocGroupBuilder {
         def repoUrl = pluginLocation + gid + "/" + id + "/"
         if (version == null) {
             def metadataURL = repoUrl + "maven-metadata.xml"
-            def metadata
             println "Version is not defined, reading latest from ${metadataURL}"
             URLConnection metadataConn = getConnectionWithBasicAuthIfNeeded(metadataURL)
             BufferedReader inBR = new BufferedReader(new InputStreamReader(metadataConn.getInputStream()))
@@ -71,7 +70,7 @@ public class JavadocGroupBuilder {
                 urlContent.append(inputLine)
             }
             inBR.close()
-            metadata = new XmlSlurper().parseText(urlContent.toString())
+            def metadata = new XmlSlurper().parseText(urlContent.toString())
             version = metadata.versioning.latest
             if (version != null && !version.trim().empty) {
                 println "Located version: ${version}"

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -70,7 +70,7 @@ public class JavadocGroupBuilder {
                     conn.setRequestProperty("Accept-Charset", "UTF-8")
                     conn.setRequestProperty("Accept-Encoding", "identity")
                     conn.setRequestProperty("User-Agent", "javadoc-generator/0.1")
-                    conn.setRequestProperty("Authorization", "Basic " + new String(Base64.getEncoder().encode((this.username + ':' + this.password)).getBytes("UTF-8")), "UTF-8"))
+                    conn.setRequestProperty("Authorization", "Basic " + new String(Base64.getEncoder().encode(this.username + ':' + this.password).getBytes("UTF-8"), "UTF-8"))
                     BufferedReader inBR = new BufferedReader(new InputStreamReader(conn.getInputStream()))
                     StringBuilder urlContent = new StringBuilder()
                     String inputLine
@@ -118,7 +118,7 @@ public class JavadocGroupBuilder {
                     conn.setRequestProperty("Accept-Charset", "UTF-8")
                     conn.setRequestProperty("Accept-Encoding", "identity")
                     conn.setRequestProperty("User-Agent", "javadoc-generator/0.1")
-                    conn.setRequestProperty("Authorization", "Basic " + new String(Base64.getEncoder().encode((this.username + ':' + this.password)).getBytes("UTF-8")), "UTF-8"))
+                    conn.setRequestProperty("Authorization", "Basic " + new String(Base64.getEncoder().encode(this.username + ':' + this.password).getBytes("UTF-8"), "UTF-8"))
                     file << conn.getInputStream()
                 } catch(UnsupportedEncodingException uee) {
                     uee.printStackTrace();

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -64,10 +64,10 @@ public class JavadocGroupBuilder {
                     conn.setRequestProperty("Accept-Encoding", "identity")
                     conn.setRequestProperty("User-Agent", "javadoc-generator/0.1")
                     conn.setRequestProperty("Authorization", "Basic " + new String(Base64.getEncoder().encode((System.getenv("ARTIFACT_CACHING_PROXY_USERNAME") + ':' + System.getenv("ARTIFACT_CACHING_PROXY_PASSWORD")).getBytes("UTF-8")), "UTF-8"))
-                    BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()))
+                    BufferedReader inBR = new BufferedReader(new InputStreamReader(conn.getInputStream()))
                     StringBuilder urlContent = new StringBuilder()
                     String inputLine
-                    while ((inputLine = in.readLine()) != null) {
+                    while ((inputLine = inBR.readLine()) != null) {
                         urlContent.append(inputLine)
                     }
                     in.close()

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -84,12 +84,11 @@ public class JavadocGroupBuilder {
             if (pluginLocation != "https://repo.jenkins-ci.org/releases/") {
                 // If we're querying one of the artifact caching proxies we need to add authentication
                 try {
-                    auth = Base64.getEncoder().encode((System.getenv("ARTIFACT_CACHING_PROXY_USERNAME") + ':' + System.getenv("ARTIFACT_CACHING_PROXY_PASSWORD")).getBytes("UTF-8"));
                     URLConnection conn = new URL(pluginLoc).openConnection();
                     conn.setRequestProperty("Accept-Charset", "UTF-8");
                     conn.setRequestProperty("Accept-Encoding", "identity");
                     conn.setRequestProperty("User-Agent", "backend-extension-indexer/0.1");
-                    conn.setRequestProperty("Authorization", "Basic " + new String(auth, "UTF-8"));
+                    conn.setRequestProperty("Authorization", "Basic " + new String(Base64.getEncoder().encode((System.getenv("ARTIFACT_CACHING_PROXY_USERNAME") + ':' + System.getenv("ARTIFACT_CACHING_PROXY_PASSWORD")).getBytes("UTF-8")), "UTF-8"));
                     file << conn.getInputStream()
                 } catch(UnsupportedEncodingException uee) {
                     uee.printStackTrace();

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -28,7 +28,7 @@ public class JavadocGroupBuilder {
                                Set<String> artifactIDs = null,
                                String pluginLocation = "https://repo.jenkins-ci.org/releases/",
                                String username = null,
-                               String password = null,
+                               String password = null
                                ) {
         this.path = path
         this.artifactType = artifactType

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -55,6 +55,7 @@ public class JavadocGroupBuilder {
         def repoUrl = pluginLocation + gid + "/" + id + "/"
         if (version == null) {
             def metadataURL = repoUrl + "/maven-metadata.xml"
+            def metadata
             println "Version is not defined, reading latest from ${metadataURL}"
             if (this.pluginLocation != "https://repo.jenkins-ci.org/releases/") {
                 // If we're querying one of the artifact caching proxies we need to add authentication
@@ -71,12 +72,12 @@ public class JavadocGroupBuilder {
                         urlContent.append(inputLine)
                     }
                     inBR.close()
-                    def metadata = new XmlSlurper().parseText(urlContent.toString())
+                    metadata = new XmlSlurper().parseText(urlContent.toString())
                 } catch(UnsupportedEncodingException uee) {
                     uee.printStackTrace();
                 }
             } else {
-                def metadata = new XmlSlurper().parseText(new URL (metadataURL).text)
+                metadata = new XmlSlurper().parseText(new URL (metadataURL).text)
             }
             version = metadata.versioning.latest
             if (version != null && !version.trim().empty) {

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -80,8 +80,10 @@ public class JavadocGroupBuilder {
         def fos = file.newOutputStream()
 
         try {
+            System.out.println("--> this.pluginLocation: " + this.pluginLocation)
+            System.out.println("--> pluginLocation: " + pluginLocation)
             // Write the contents of the *-javadoc.jar to the file
-            if (pluginLocation != "https://repo.jenkins-ci.org/releases/") {
+            if (this.pluginLocation != "https://repo.jenkins-ci.org/releases/") {
                 // If we're querying one of the artifact caching proxies we need to add authentication
                 try {
                     URLConnection conn = new URL(pluginLoc).openConnection();

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -52,7 +52,7 @@ public class JavadocGroupBuilder {
 
         def repoUrl = pluginLocation + gid + "/" + id + "/"
         if (version == null) {
-            def metadataURL = repoUrl + "maven-metadata.xml"
+            def metadataURL = "https://repo.jenkins-ci.org/releases/" + gid + "/" + id + "/maven-metadata.xml"
             println "Version is not defined, reading latest from ${metadataURL}"
             def metadata = new XmlSlurper().parseText(new URL (metadataURL).text)
             version = metadata.versioning.latest
@@ -80,8 +80,6 @@ public class JavadocGroupBuilder {
         def fos = file.newOutputStream()
 
         try {
-            System.out.println("--> this.pluginLocation: " + this.pluginLocation)
-            System.out.println("--> pluginLocation: " + pluginLocation)
             // Write the contents of the *-javadoc.jar to the file
             if (this.pluginLocation != "https://repo.jenkins-ci.org/releases/") {
                 // If we're querying one of the artifact caching proxies we need to add authentication

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -69,13 +69,12 @@ public class JavadocGroupBuilder {
                         urlContent.append(inputLine)
                     }
                     in.close()
-                    return response.toString()
-                    def metadata = new XmlSlurper().parseText(response.toString())
+                    def metadata = new XmlSlurper().parseText(urlContent.toString())
                 } catch(UnsupportedEncodingException uee) {
                     uee.printStackTrace();
                 }
             } else {
-                def metadata = new XmlSlurper().parseText(urlContent.toString())
+                def metadata = new XmlSlurper().parseText(new URL (metadataURL).text)
             }
             version = metadata.versioning.latest
             if (version != null && !version.trim().empty) {

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -54,7 +54,7 @@ public class JavadocGroupBuilder {
 
         def repoUrl = pluginLocation + gid + "/" + id + "/"
         if (version == null) {
-            def metadataURL = repoUrl + "/maven-metadata.xml"
+            def metadataURL = repoUrl + "maven-metadata.xml"
             def metadata
             println "Version is not defined, reading latest from ${metadataURL}"
             if (this.pluginLocation != "https://repo.jenkins-ci.org/releases/") {


### PR DESCRIPTION
This PR is adding authentication via a basic auth for downloads done on an artifact caching proxy provider instead of the JFrog Artifactory repo.jenkins-ci.org.

It doesn't use the artifact caching proxy if it's running locally in Docker, or if it's running on trusted.ci.jenkins.io, as the corresponding credentials aren't stored there and as we're taking precaution on this sensible instance.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752