### PR TITLE
Remove 'script' from header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 *.sw*
 .idea
+jq

--- a/src/main/groovy/JavadocGroupBuilder.groovy
+++ b/src/main/groovy/JavadocGroupBuilder.groovy
@@ -42,7 +42,6 @@ public class JavadocGroupBuilder {
         indexHtml << "<html><head><title>${title}</title>"
         indexHtml << '<meta http-equiv="content-type" content="text/html; charset=UTF-8"/>'
         indexHtml << '<link rel="stylesheet" type="text/css" href="style.css"/>'
-        indexHtml << '<script src="script.js"></script>'
         indexHtml << '</head><body>'
     }
 


### PR DESCRIPTION
There's no `script.js` served that could be added to the header. I propose removing this line to keep the errors down to a minimum.