### PR TITLE
Adjust cron schedule

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '2')),
-    pipelineTriggers([cron('H 5 * * 1')]),
+    pipelineTriggers([cron('H 5 * * 3')]),
 ])
 
 node('linux') {


### PR DESCRIPTION
The change proposed adjusts the schedule to run on Wednesday's rather than Monday's, to pick up javadoc changes of weekly core releases timely, instead of running the Monday the week after the weekly release.