### PR TITLE
feat: bump Nginx to stable 1.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use nginx stable
-FROM nginx:1.23.4
+# Use nginx stable (even minor version)
+FROM nginx:1.24.0
 
 ARG PUBLISH_PATH=/usr/share/nginx/html
 


### PR DESCRIPTION
The nginx stable line uses an even number for the minor version digit: http://nginx.org/en/download.html

As dependabot keeps bumping it here from odd to odd number, I'm changing the version manually to stop this unwanted behavior, assuming it will shift to stable (even) versions