### PR TITLE
chore: use `azcopy` in parallel to `blobxfer` for publication

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ node('linux') {
                         servicePrincipalCredentialsId: 'trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer',
                         fileShare: 'javadoc-jenkins-io',
                         fileShareStorageAccount: 'javadocjenkinsio',
-                        durationInMinute: 45
+                        durationInMinute: 20
                     ]) {
                         sh '''
                         # Don't output sensitive information


### PR DESCRIPTION
This PR adds a step to use `azcopy` to synchronize content in a new Premium File Share in parallel of `blobxfer` (for now).

When all the process will be validated, `blobxfer` and related code and script will be removed in favor of `azcopy`.

Tested via a replay of the main job on trusted.ci.jenkins.io: https://trusted.ci.jenkins.io:1443/job/javadoc/326/

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1964568638