### PR TITLE
Revert "chore(javadoc): Change agent node to arm64"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,7 @@ properties([
     pipelineTriggers([cron('H 5 * * 3')]),
 ])
 
-// 'linux-arm64' is a common label between ci.jenkins.io and infra.ci.jenkins.io for obtaining ARM64 Linux VM with Docker
-node('linux-arm64') {
+node('linux') {
     checkout scm
 
     dir("scripts/build") {


### PR DESCRIPTION
Reverts jenkins-infra/javadoc#70

need to check on trusted.ci for this agent not infra.ci