### PR TITLE
chore(Jenkinsfile) fix ACP errorsd on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,15 +26,8 @@ node('linux') {
             if (infra.isTrusted()) {
                 sh './scripts/generate-javadoc.sh'
             } else {
-                withCredentials([usernamePassword(
-                    credentialsId: 'artifact-caching-proxy-credentials',
-                    usernameVariable: 'ARTIFACT_CACHING_PROXY_USERNAME',
-                    passwordVariable: 'ARTIFACT_CACHING_PROXY_PASSWORD'
-                )]) {
-                    def repositoryOrigin = "https://repo." + (env.ARTIFACT_CACHING_PROXY_PROVIDER ?: 'azure') + ".jenkins.io"
-                    withEnv(["ARTIFACT_CACHING_PROXY_ORIGIN=${repositoryOrigin}"]) {
-                        sh './scripts/generate-javadoc.sh'
-                    }
+                withArtifactCachingProxy(true) {
+                    sh './scripts/generate-javadoc.sh'
                 }
             }
         }


### PR DESCRIPTION
The builds are failing on ci.jenkins.io with the following error:

```
ERROR: Could not find credentials entry with ID 'artifact-caching-proxy-credentials'
```

This PR fixes the issue by removing the current ACP (Artifact Caching Proxy) implementation to the pipeline library abstracting away the user/password/server logic