### PR TITLE
Test of jenkins-infra/pipeline-library#972

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,6 @@
 #!/usr/bin/env groovy
-
-properties([
-    buildDiscarder(logRotator(numToKeepStr: '2')),
-    pipelineTriggers([cron('H 5 * * 3')]),
-])
+// Test of https://github.com/jenkins-infra/pipeline-library/pull/972
+@Library('pipeline-library@pull/972/head') _
 
 node('linux') {
     checkout scm
@@ -16,41 +13,8 @@ node('linux') {
         deleteDir()
     }
 
-    stage('Generate Javadocs') {
-        withEnv([
-                "PATH+MVN=${tool 'mvn'}/bin",
-                "JAVA_HOME=${tool 'jdk17'}",
-                "PATH+GROOVY=${tool 'groovy'}/bin",
-                "PATH+JAVA=${tool 'jdk17'}/bin",
-        ]) {
-            if (infra.isTrusted()) {
-                sh './scripts/generate-javadoc.sh'
-            } else {
-                infra.withArtifactCachingProxy(true) {
-                    sh './scripts/generate-javadoc.sh'
-                }
-            }
-        }
-    }
-
-    stage('Generate Shortnames') {
-        sh './scripts/generate-shortnames.sh'
-    }
-
-    stage('Prepare Latest') {
-        sh './scripts/default-to-latest.sh'
-    }
-
-    stage('Archive') {
-        sh 'cd build && tar -cjf javadoc-site.tar.bz2 site'
-        archiveArtifacts artifacts: 'build/*.tar.bz2',
-                            allowEmptyArchive: false,
-                            fingerprint: false,
-                            onlyIfSuccessful: true
-    }
-
     if (infra.isTrusted()){
-        stage('Publish on Azure') {
+        stage('Get lenght of FILESHARE_SIGNED_URL from "withFileShareServicePrincipal" function') {
             try {
                 infra.withFileShareServicePrincipal([
                     servicePrincipalCredentialsId: 'trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer',
@@ -59,37 +23,12 @@ node('linux') {
                     durationInMinute: 30
                 ]) {
                     sh '''
-                    # Don't output sensitive information
-                    set +x
-    
-                    # Synchronize the File Share content
-                    azcopy sync \
-                        --skip-version-check \
-                        --recursive=true\
-                        --delete-destination=true \
-                        --compare-hash=MD5 \
-                        --put-md5 \
-                        --local-hash-storage-mode=HiddenFiles \
-                        ./build/site/ "${FILESHARE_SIGNED_URL}"
+                    length=${#FILESHARE_SIGNED_URL}
+
+                    echo "FILESHARE_SIGNED_URL lenght: ${length}"
                     '''
                 }
-            } catch (err) {
-                currentBuild.result = 'FAILURE'
-                // Only collect azcopy log when the deployment fails, because it is an heavy one
-                sh '''
-                # Retrieve azcopy logs to archive them
-                cat /home/jenkins/.azcopy/*.log > azcopy.log
-                '''
-                archiveArtifacts 'azcopy.log'
-                
             }
-        }
-    }
-
-    stage('Clean up') {
-        echo 'We want to generate fresh javadocs on each run'
-        dir('build/site') {
-            deleteDir()
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,19 +15,17 @@ node('linux') {
 
     if (infra.isTrusted()){
         stage('Get lenght of FILESHARE_SIGNED_URL from "withFileShareServicePrincipal" function') {
-            try {
-                infra.withFileShareServicePrincipal([
-                    servicePrincipalCredentialsId: 'trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer',
-                    fileShare: 'javadoc-jenkins-io',
-                    fileShareStorageAccount: 'javadocjenkinsio',
-                    durationInMinute: 30
-                ]) {
-                    sh '''
-                    length=${#FILESHARE_SIGNED_URL}
+            infra.withFileShareServicePrincipal([
+                servicePrincipalCredentialsId: 'trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer',
+                fileShare: 'javadoc-jenkins-io',
+                fileShareStorageAccount: 'javadocjenkinsio',
+                durationInMinute: 30
+            ]) {
+                sh '''
+                length=${#FILESHARE_SIGNED_URL}
 
-                    echo "FILESHARE_SIGNED_URL lenght: ${length}"
-                    '''
-                }
+                echo "FILESHARE_SIGNED_URL lenght: ${length}"
+                '''
             }
         }
     }


### PR DESCRIPTION
This PR is a test to ensure `infra.withFileShareServicePrincipal` still returns a non-empty `FILESHARE_SIGNED_URL` after moving get-fileshare-signed-url.sh script to the pipeline resource folder in https://github.com/jenkins-infra/pipeline-library/pull/972

Replay in trusted.ci.jenkins.io: https://trusted.ci.jenkins.io/job/javadoc/449 ([diff](https://trusted.ci.jenkins.io/job/javadoc/449/replay/diff))
