### PR TITLE
chore(pipeline): use credential-less `infra.withFileShareServicePrincipal`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,6 @@ node('linux') {
         stage('Publish on Azure') {
             try {
                 infra.withFileShareServicePrincipal([
-                    servicePrincipalCredentialsId: 'trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer',
                     fileShare: 'javadoc-jenkins-io',
                     fileShareStorageAccount: 'javadocjenkinsio',
                     durationInMinute: 30


### PR DESCRIPTION
This PR uses `trusted-ci-jenkins-io-agents` UAID of trusted.ci.jenkins.io VM agents instead of `trustedci_javadocjenkinsio_fileshare_serviceprincipal_writer` Azure SP credentials.

In draft until https://github.com/jenkins-infra/pipeline-library/pull/973 is merged. (related: https://github.com/jenkins-infra/helpdesk/issues/4915#issuecomment-3671298097)

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/4914#issuecomment-3664925220